### PR TITLE
Depend on only the `BufStream` trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 bytes = "0.4.11"
 futures = "0.1.25"
 http = "0.1.16"
-tokio-buf = "0.1.0"
+tokio-buf = { version = "0.1.0", default-features = false }


### PR DESCRIPTION
The default set of features includes utilities.