### PR TITLE
Make default is_end_stream pessimistically return false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,7 @@ pub trait Body {
     /// A return value of `false` **does not** guarantee that a value will be
     /// returned from `poll_stream` or `poll_trailers`.
     fn is_end_stream(&self) -> bool {
-        let size_hint = self.size_hint();
-
-        size_hint
-            .upper()
-            .map(|upper| upper == 0 && upper == size_hint.lower())
-            .unwrap_or(false)
+        false
     }
 
     /// Returns the bounds on the remaining length of the stream.

--- a/tests/is_end_stream.rs
+++ b/tests/is_end_stream.rs
@@ -37,7 +37,7 @@ fn is_end_stream_true() {
         (Some(123), None, false),
         (Some(0), Some(123), false),
         (Some(123), Some(123), false),
-        (Some(0), Some(0), true),
+        (Some(0), Some(0), false),
     ];
 
     for &(lower, upper, is_end_stream) in &combos {


### PR DESCRIPTION
The previous default could report the stream was ended even though there may have been pending `trailers`.