### PR TITLE
Add SizeHint::with_exact

### DIFF
--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -4,14 +4,12 @@ use std::u64;
 ///
 /// The default implementation returns:
 ///
-/// * 0 for `available`
 /// * 0 for `lower`
 /// * `None` for `upper`.
 #[derive(Debug, Default, Clone)]
 pub struct SizeHint {
     lower: u64,
     upper: Option<u64>,
-    ready: bool,
 }
 
 impl SizeHint {
@@ -53,8 +51,6 @@ impl SizeHint {
     /// This function panics if `value` is less than `lower`.
     #[inline]
     pub fn set_upper(&mut self, value: u64) {
-        // There is no need to check `available` as that is guaranteed to be
-        // less than or equal to `lower`.
         assert!(value >= self.lower, "`value` is less than than `lower`");
 
         self.upper = Some(value);

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -23,7 +23,10 @@ impl SizeHint {
     /// given value.
     #[inline]
     pub fn with_exact(value: u64) -> SizeHint {
-        SizeHint { lower: value, upper: Some(value) }
+        SizeHint {
+            lower: value,
+            upper: Some(value),
+        }
     }
 
     /// Returns the lower bound of data that the `Body` will yield before

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -19,6 +19,13 @@ impl SizeHint {
         SizeHint::default()
     }
 
+    /// Returns a new `SizeHint` with both upper and lower bounds set to the
+    /// given value.
+    #[inline]
+    pub fn with_exact(value: u64) -> SizeHint {
+        SizeHint { lower: value, upper: Some(value) }
+    }
+
     /// Returns the lower bound of data that the `Body` will yield before
     /// completing.
     #[inline]


### PR DESCRIPTION
Firstly, I just removed a unused field and associated comments that were kind of in the way.  If there is further merit to that, then I suggest it be added in complete form when its ready.

Then, from my own first use, and hyper master branch usage, it would appear that the _exact_ form of SizeHint is the common case, so add a dedicated constructor for that case, reducing use to a simple one liner.