### PR TITLE
Add Next futures conveniences

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! [`Body`]: trait.Body.html
 
-mod size_hint;
 mod next;
+mod size_hint;
 
 pub use self::next::{NextData, NextTrailers};
 pub use self::size_hint::SizeHint;
@@ -69,12 +69,18 @@ pub trait Body {
     }
 
     /// Returns future that resolves to next data chunk, if any.
-    fn next_data(&mut self) -> NextData<'_, Self> where Self: Sized {
+    fn next_data(&mut self) -> NextData<'_, Self>
+    where
+        Self: Sized,
+    {
         NextData(self)
     }
 
     /// Returns future that resolves to next data chunk, if any.
-    fn next_trailers(&mut self) -> NextTrailers<'_, Self> where Self: Sized {
+    fn next_trailers(&mut self) -> NextTrailers<'_, Self>
+    where
+        Self: Sized,
+    {
         NextTrailers(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub trait Body {
     /// Returns future that resolves to next data chunk, if any.
     fn next_data(&mut self) -> NextData<'_, Self>
     where
-        Self: Sized,
+        Self: Unpin,
     {
         NextData(self)
     }
@@ -79,7 +79,7 @@ pub trait Body {
     /// Returns future that resolves to next data chunk, if any.
     fn next_trailers(&mut self) -> NextTrailers<'_, Self>
     where
-        Self: Sized,
+        Self: Unpin,
     {
         NextTrailers(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 mod next;
 mod size_hint;
 
-pub use self::next::{NextData, NextTrailers};
+pub use self::next::{Next, Trailers};
 pub use self::size_hint::SizeHint;
 
 use bytes::Buf;
@@ -69,19 +69,19 @@ pub trait Body {
     }
 
     /// Returns future that resolves to next data chunk, if any.
-    fn next(&mut self) -> NextData<'_, Self>
+    fn next(&mut self) -> Next<'_, Self>
     where
         Self: Unpin,
     {
-        NextData(self)
+        Next(self)
     }
 
     /// Returns future that resolves to trailers, if any.
-    fn trailers(&mut self) -> NextTrailers<'_, Self>
+    fn trailers(&mut self) -> Trailers<'_, Self>
     where
         Self: Unpin,
     {
-        NextTrailers(self)
+        Trailers(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,15 +69,15 @@ pub trait Body {
     }
 
     /// Returns future that resolves to next data chunk, if any.
-    fn next_data(&mut self) -> NextData<'_, Self>
+    fn next(&mut self) -> NextData<'_, Self>
     where
         Self: Unpin,
     {
         NextData(self)
     }
 
-    /// Returns future that resolves to next trailers, if any.
-    fn next_trailers(&mut self) -> NextTrailers<'_, Self>
+    /// Returns future that resolves to trailers, if any.
+    fn trailers(&mut self) -> NextTrailers<'_, Self>
     where
         Self: Unpin,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub trait Body {
         NextData(self)
     }
 
-    /// Returns future that resolves to next data chunk, if any.
+    /// Returns future that resolves to next trailers, if any.
     fn next_trailers(&mut self) -> NextTrailers<'_, Self>
     where
         Self: Unpin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@
 //! [`Body`]: trait.Body.html
 
 mod size_hint;
+mod next;
 
+pub use self::next::{NextData, NextTrailers};
 pub use self::size_hint::SizeHint;
 
 use bytes::Buf;
@@ -64,6 +66,16 @@ pub trait Body {
     /// will equal the lower bound.
     fn size_hint(&self) -> SizeHint {
         SizeHint::default()
+    }
+
+    /// Returns future that resolves to next data chunk, if any.
+    fn next_data(&mut self) -> NextData<'_, Self> where Self: Sized {
+        NextData(self)
+    }
+
+    /// Returns future that resolves to next data chunk, if any.
+    fn next_trailers(&mut self) -> NextTrailers<'_, Self> where Self: Sized {
+        NextTrailers(self)
     }
 }
 

--- a/src/next.rs
+++ b/src/next.rs
@@ -7,7 +7,7 @@ use core::pin::Pin;
 use core::task;
 
 #[derive(Debug)]
-///Future that resolves to the next data chunk from `Body`
+/// Future that resolves to the next data chunk from `Body`
 pub struct NextData<'a, T>(pub(crate) &'a mut T);
 
 impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
@@ -21,7 +21,7 @@ impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
 }
 
 #[derive(Debug)]
-///Future that resolves to the optional trailers from `Body`
+/// Future that resolves to the optional trailers from `Body`
 pub struct NextTrailers<'a, T>(pub(crate) &'a mut T);
 
 impl<'a, T: Body + Unpin> Future for NextTrailers<'a, T> {

--- a/src/next.rs
+++ b/src/next.rs
@@ -14,9 +14,7 @@ impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
     type Output = Option<Result<T::Data, T::Error>>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let body = unsafe {
-            self.map_unchecked_mut(|this| &mut this.0)
-        };
+        let body = unsafe { self.map_unchecked_mut(|this| &mut this.0) };
 
         Body::poll_data(body, ctx)
     }
@@ -30,9 +28,7 @@ impl<'a, T: Body + Unpin> Future for NextTrailers<'a, T> {
     type Output = Result<Option<http::HeaderMap>, T::Error>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let body = unsafe {
-            self.map_unchecked_mut(|this| &mut this.0)
-        };
+        let body = unsafe { self.map_unchecked_mut(|this| &mut this.0) };
 
         Body::poll_trailers(body, ctx)
     }

--- a/src/next.rs
+++ b/src/next.rs
@@ -8,9 +8,9 @@ use core::task;
 
 #[derive(Debug)]
 /// Future that resolves to the next data chunk from `Body`
-pub struct NextData<'a, T: ?Sized>(pub(crate) &'a mut T);
+pub struct Next<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin + ?Sized> Future for NextData<'a, T> {
+impl<'a, T: Body + Unpin + ?Sized> Future for Next<'a, T> {
     type Output = Option<Result<T::Data, T::Error>>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
@@ -22,9 +22,9 @@ impl<'a, T: Body + Unpin + ?Sized> Future for NextData<'a, T> {
 
 #[derive(Debug)]
 /// Future that resolves to the optional trailers from `Body`
-pub struct NextTrailers<'a, T: ?Sized>(pub(crate) &'a mut T);
+pub struct Trailers<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin + ?Sized> Future for NextTrailers<'a, T> {
+impl<'a, T: Body + Unpin + ?Sized> Future for Trailers<'a, T> {
     type Output = Result<Option<http::HeaderMap>, T::Error>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {

--- a/src/next.rs
+++ b/src/next.rs
@@ -1,0 +1,39 @@
+//! Next futures for `Body`
+
+use crate::Body;
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task;
+
+#[derive(Debug)]
+///Future that resolves to the next data chunk from `Body`
+pub struct NextData<'a, T>(pub(crate) &'a mut T);
+
+impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
+    type Output = Option<Result<T::Data, T::Error>>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        let body = unsafe {
+            self.map_unchecked_mut(|this| &mut this.0)
+        };
+
+        Body::poll_data(body, ctx)
+    }
+}
+
+#[derive(Debug)]
+///Future that resolves to the optional trailers from `Body`
+pub struct NextTrailers<'a, T>(pub(crate) &'a mut T);
+
+impl<'a, T: Body + Unpin> Future for NextTrailers<'a, T> {
+    type Output = Result<Option<http::HeaderMap>, T::Error>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        let body = unsafe {
+            self.map_unchecked_mut(|this| &mut this.0)
+        };
+
+        Body::poll_trailers(body, ctx)
+    }
+}

--- a/src/next.rs
+++ b/src/next.rs
@@ -8,9 +8,9 @@ use core::task;
 
 #[derive(Debug)]
 /// Future that resolves to the next data chunk from `Body`
-pub struct NextData<'a, T>(pub(crate) &'a mut T);
+pub struct NextData<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
+impl<'a, T: Body + Unpin + ?Sized> Future for NextData<'a, T> {
     type Output = Option<Result<T::Data, T::Error>>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
@@ -22,9 +22,9 @@ impl<'a, T: Body + Unpin> Future for NextData<'a, T> {
 
 #[derive(Debug)]
 /// Future that resolves to the optional trailers from `Body`
-pub struct NextTrailers<'a, T>(pub(crate) &'a mut T);
+pub struct NextTrailers<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin> Future for NextTrailers<'a, T> {
+impl<'a, T: Body + Unpin + ?Sized> Future for NextTrailers<'a, T> {
     type Output = Result<Option<http::HeaderMap>, T::Error>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {


### PR DESCRIPTION
Adds trivial futures that return next data chunk and trailers.

Basically it is convenience for users so that they wouldn't need to wrap `next_*` into future object themself.
Since it takes reference, it is forced to have `Unpin` requirement, guess it is sad