### PR TITLE
Rename the 'next' combinator to 'data'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 mod next;
 mod size_hint;
 
-pub use self::next::{Next, Trailers};
+pub use self::next::{Data, Trailers};
 pub use self::size_hint::SizeHint;
 
 use bytes::Buf;
@@ -69,11 +69,11 @@ pub trait Body {
     }
 
     /// Returns future that resolves to next data chunk, if any.
-    fn next(&mut self) -> Next<'_, Self>
+    fn data(&mut self) -> Data<'_, Self>
     where
         Self: Unpin + Sized,
     {
-        Next(self)
+        Data(self)
     }
 
     /// Returns future that resolves to trailers, if any.

--- a/src/next.rs
+++ b/src/next.rs
@@ -1,16 +1,15 @@
-//! Next futures for `Body`
-
 use crate::Body;
 
 use core::future::Future;
 use core::pin::Pin;
 use core::task;
 
+#[must_use = "futures don't do anything unless polled"]
 #[derive(Debug)]
 /// Future that resolves to the next data chunk from `Body`
-pub struct Next<'a, T: ?Sized>(pub(crate) &'a mut T);
+pub struct Data<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin + ?Sized> Future for Next<'a, T> {
+impl<'a, T: Body + Unpin + ?Sized> Future for Data<'a, T> {
     type Output = Option<Result<T::Data, T::Error>>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
@@ -18,6 +17,7 @@ impl<'a, T: Body + Unpin + ?Sized> Future for Next<'a, T> {
     }
 }
 
+#[must_use = "futures don't do anything unless polled"]
 #[derive(Debug)]
 /// Future that resolves to the optional trailers from `Body`
 pub struct Trailers<'a, T: ?Sized>(pub(crate) &'a mut T);


### PR DESCRIPTION
I find this name a little clearer, and it also fixes a conflict if something implements both `Body` and `Stream`.