### PR TITLE
Fix the documentation link in the Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 edition = "2018"
 readme = "README.md"
-documentation = "https://docs.rs/http-body/0.3.0/http-body"
+documentation = "https://docs.rs/http-body/"
 repository = "https://github.com/hyperium/http-body"
 license = "MIT"
 description = """


### PR DESCRIPTION
There are two issues with the link:
- The second "http-body" should use `_` instead of `-`.
- The link is outdated (the last version is 0.3.1).

I suppose the version part can be removed from the link, in that case it resolves into a link to the last published version.