### PR TITLE
Add `Empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add `Empty`.
+
 # 0.4.0 (December 23, 2020)
 
 - Update `bytes` to v1.0.

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -11,7 +11,7 @@ use std::{
 /// A body that is always empty.
 #[derive(Debug, Clone, Copy)]
 pub struct Empty<D> {
-    _marker: PhantomData<D>,
+    _marker: PhantomData<fn() -> D>,
 }
 
 impl<D> Default for Empty<D> {

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -3,23 +3,15 @@ use bytes::Buf;
 use http::HeaderMap;
 use std::{
     convert::Infallible,
+    fmt,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 
 /// A body that is always empty.
-#[derive(Debug, Clone, Copy)]
 pub struct Empty<D> {
     _marker: PhantomData<fn() -> D>,
-}
-
-impl<D> Default for Empty<D> {
-    fn default() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
-    }
 }
 
 impl<D> Empty<D> {
@@ -49,3 +41,27 @@ impl<D: Buf> Body for Empty<D> {
         Poll::Ready(Ok(None))
     }
 }
+
+impl<D> fmt::Debug for Empty<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Empty").finish()
+    }
+}
+
+impl<D> Default for Empty<D> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<D> Clone for Empty<D> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<D> Copy for Empty<D> {}

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -1,0 +1,51 @@
+use super::Body;
+use bytes::Buf;
+use http::HeaderMap;
+use std::{
+    convert::Infallible,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A body that is always empty.
+#[derive(Debug, Clone, Copy)]
+pub struct Empty<D> {
+    _marker: PhantomData<D>,
+}
+
+impl<D> Default for Empty<D> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<D> Empty<D> {
+    /// Create a new `Empty`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<D: Buf> Body for Empty<D> {
+    type Data = D;
+    type Error = Infallible;
+
+    #[inline]
+    fn poll_data(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        Poll::Ready(None)
+    }
+
+    #[inline]
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,11 @@
 //!
 //! [`Body`]: trait.Body.html
 
+mod empty;
 mod next;
 mod size_hint;
 
+pub use self::empty::Empty;
 pub use self::next::{Data, Trailers};
 pub use self::size_hint::SizeHint;
 


### PR DESCRIPTION
`Empty` is a little utility type that I have found useful in a few
scenarios. For example to make a "catch all" `tower::Service` that
always returns `404 Not Found` with an empty body.