### PR TITLE
Fix some docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-Nothing.
+- Fix docs links for `map_data` and `map_err`.
 
 # 0.4.1 (March 18, 2021)
 

--- a/src/combinators/map_data.rs
+++ b/src/combinators/map_data.rs
@@ -9,7 +9,7 @@ use std::{
 pin_project! {
     /// Body returned by the [`map_data`] combinator.
     ///
-    /// [`map_data`]: crate::util::BodyExt::map_data
+    /// [`map_data`]: crate::Body::map_data
     #[derive(Debug, Clone, Copy)]
     pub struct MapData<B, F> {
         #[pin]

--- a/src/combinators/map_err.rs
+++ b/src/combinators/map_err.rs
@@ -8,7 +8,7 @@ use std::{
 pin_project! {
     /// Body returned by the [`map_err`] combinator.
     ///
-    /// [`map_err`]: crate::util::BodyExt::map_err
+    /// [`map_err`]: crate::Body::map_err
     #[derive(Debug, Clone, Copy)]
     pub struct MapErr<B, F> {
         #[pin]


### PR DESCRIPTION
I assume this wasn't caught by `broken_intra_doc_links` because of
`pin_project!`.