### PR TITLE
Add `Full`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ categories = ["web-programming"]
 bytes = "1"
 http = "0.2"
 pin-project-lite = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/src/full.rs
+++ b/src/full.rs
@@ -1,0 +1,157 @@
+use crate::{Body, SizeHint};
+use bytes::{Buf, Bytes};
+use http::HeaderMap;
+use std::borrow::Cow;
+use std::convert::{Infallible, TryFrom};
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A body that consists of a single chunk.
+#[derive(Clone, Copy, Debug)]
+pub struct Full<D> {
+    data: Option<D>,
+}
+
+impl<D> Full<D>
+where
+    D: Buf + Unpin,
+{
+    /// Create a new `Full`.
+    pub fn new(data: D) -> Self {
+        let data = if data.has_remaining() {
+            Some(data)
+        } else {
+            None
+        };
+        Full { data }
+    }
+}
+
+impl<D> Body for Full<D>
+where
+    D: Buf + Unpin,
+{
+    type Data = D;
+    type Error = Infallible;
+
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<D, Self::Error>>> {
+        Poll::Ready(self.data.take().map(Ok))
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data.is_none()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.data
+            .as_ref()
+            .map(|data| {
+                u64::try_from(data.remaining())
+                    .map(SizeHint::with_exact)
+                    .unwrap_or_else(|_| {
+                        let mut hint = SizeHint::new();
+                        hint.set_lower(u64::MAX);
+                        hint
+                    })
+            })
+            .unwrap_or_else(|| SizeHint::with_exact(0))
+    }
+}
+
+impl<D> Default for Full<D>
+where
+    D: Buf + Unpin,
+{
+    /// Create an empty `Full`.
+    fn default() -> Self {
+        Full { data: None }
+    }
+}
+
+impl<D> From<Bytes> for Full<D>
+where
+    D: Buf + From<Bytes> + Unpin,
+{
+    fn from(bytes: Bytes) -> Self {
+        Full::new(D::from(bytes))
+    }
+}
+
+impl<D> From<Vec<u8>> for Full<D>
+where
+    D: Buf + From<Vec<u8>> + Unpin,
+{
+    fn from(vec: Vec<u8>) -> Self {
+        Full::new(D::from(vec))
+    }
+}
+
+impl<D> From<&'static [u8]> for Full<D>
+where
+    D: Buf + From<&'static [u8]> + Unpin,
+{
+    fn from(slice: &'static [u8]) -> Self {
+        Full::new(D::from(slice))
+    }
+}
+
+impl<D, B> From<Cow<'static, B>> for Full<D>
+where
+    D: Buf + From<&'static B> + From<B::Owned> + Unpin,
+    B: ToOwned + ?Sized,
+{
+    fn from(cow: Cow<'static, B>) -> Self {
+        match cow {
+            Cow::Borrowed(b) => Full::new(D::from(b)),
+            Cow::Owned(o) => Full::new(D::from(o)),
+        }
+    }
+}
+
+impl<D> From<String> for Full<D>
+where
+    D: Buf + From<String> + Unpin,
+{
+    fn from(s: String) -> Self {
+        Full::new(D::from(s))
+    }
+}
+
+impl<D> From<&'static str> for Full<D>
+where
+    D: Buf + From<&'static str> + Unpin,
+{
+    fn from(slice: &'static str) -> Self {
+        Full::new(D::from(slice))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn full_returns_some() {
+        let mut full = Full::new(&b"hello"[..]);
+        assert_eq!(full.size_hint().exact(), Some(b"hello".len() as u64));
+        assert_eq!(full.data().await, Some(Ok(&b"hello"[..])));
+        assert!(full.data().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_full_returns_none() {
+        assert!(Full::<&[u8]>::default().data().await.is_none());
+        assert!(Full::new(&b""[..]).data().await.is_none());
+    }
+}

--- a/src/full.rs
+++ b/src/full.rs
@@ -1,21 +1,23 @@
 use crate::{Body, SizeHint};
 use bytes::{Buf, Bytes};
 use http::HeaderMap;
+use pin_project_lite::pin_project;
 use std::borrow::Cow;
 use std::convert::{Infallible, TryFrom};
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// A body that consists of a single chunk.
-#[derive(Clone, Copy, Debug)]
-pub struct Full<D> {
-    data: Option<D>,
+pin_project! {
+    /// A body that consists of a single chunk.
+    #[derive(Clone, Copy, Debug)]
+    pub struct Full<D> {
+        data: Option<D>,
+    }
 }
 
 impl<D> Full<D>
 where
-    D: Buf + Unpin,
+    D: Buf,
 {
     /// Create a new `Full`.
     pub fn new(data: D) -> Self {
@@ -30,7 +32,7 @@ where
 
 impl<D> Body for Full<D>
 where
-    D: Buf + Unpin,
+    D: Buf,
 {
     type Data = D;
     type Error = Infallible;
@@ -71,7 +73,7 @@ where
 
 impl<D> Default for Full<D>
 where
-    D: Buf + Unpin,
+    D: Buf,
 {
     /// Create an empty `Full`.
     fn default() -> Self {
@@ -81,7 +83,7 @@ where
 
 impl<D> From<Bytes> for Full<D>
 where
-    D: Buf + From<Bytes> + Unpin,
+    D: Buf + From<Bytes>,
 {
     fn from(bytes: Bytes) -> Self {
         Full::new(D::from(bytes))
@@ -90,7 +92,7 @@ where
 
 impl<D> From<Vec<u8>> for Full<D>
 where
-    D: Buf + From<Vec<u8>> + Unpin,
+    D: Buf + From<Vec<u8>>,
 {
     fn from(vec: Vec<u8>) -> Self {
         Full::new(D::from(vec))
@@ -99,7 +101,7 @@ where
 
 impl<D> From<&'static [u8]> for Full<D>
 where
-    D: Buf + From<&'static [u8]> + Unpin,
+    D: Buf + From<&'static [u8]>,
 {
     fn from(slice: &'static [u8]) -> Self {
         Full::new(D::from(slice))
@@ -108,7 +110,7 @@ where
 
 impl<D, B> From<Cow<'static, B>> for Full<D>
 where
-    D: Buf + From<&'static B> + From<B::Owned> + Unpin,
+    D: Buf + From<&'static B> + From<B::Owned>,
     B: ToOwned + ?Sized,
 {
     fn from(cow: Cow<'static, B>) -> Self {
@@ -121,7 +123,7 @@ where
 
 impl<D> From<String> for Full<D>
 where
-    D: Buf + From<String> + Unpin,
+    D: Buf + From<String>,
 {
     fn from(s: String) -> Self {
         Full::new(D::from(s))
@@ -130,7 +132,7 @@ where
 
 impl<D> From<&'static str> for Full<D>
 where
-    D: Buf + From<&'static str> + Unpin,
+    D: Buf + From<&'static str>,
 {
     fn from(slice: &'static str) -> Self {
         Full::new(D::from(slice))

--- a/src/full.rs
+++ b/src/full.rs
@@ -58,15 +58,7 @@ where
     fn size_hint(&self) -> SizeHint {
         self.data
             .as_ref()
-            .map(|data| {
-                u64::try_from(data.remaining())
-                    .map(SizeHint::with_exact)
-                    .unwrap_or_else(|_| {
-                        let mut hint = SizeHint::new();
-                        hint.set_lower(u64::MAX);
-                        hint
-                    })
-            })
+            .map(|data| SizeHint::with_exact(u64::try_from(data.remaining()).unwrap()))
             .unwrap_or_else(|| SizeHint::with_exact(0))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@
 //! [`Body`]: trait.Body.html
 
 mod empty;
+mod full;
 mod next;
 mod size_hint;
 
 pub mod combinators;
 
 pub use self::empty::Empty;
+pub use self::full::Full;
 pub use self::next::{Data, Trailers};
 pub use self::size_hint::SizeHint;
 


### PR DESCRIPTION
This implements a part of hyperium/hyper#2345.

This implements `Clone` and, for example, a client can clone it to retry requests (e.g. for [redirections][tower-http-79]).

[tower-http-79]: https://github.com/tower-rs/tower-http/pull/79