### PR TITLE
Correctly override `size_hint` and `is_end_stream` for `Empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-Nothing.
+- Correctly override `Body::size_hint` and `Body::is_end_stream` for `Empty`.
 
 # 0.4.1 (March 18, 2021)
 

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -1,4 +1,4 @@
-use super::Body;
+use super::{Body, SizeHint};
 use bytes::Buf;
 use http::HeaderMap;
 use std::{
@@ -39,6 +39,14 @@ impl<D: Buf> Body for Empty<D> {
         _cx: &mut Context<'_>,
     ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
         Poll::Ready(Ok(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        true
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(0)
     }
 }
 


### PR DESCRIPTION
I noticed this while working on https://github.com/hyperium/tonic/pull/622 as it broke some interop tests.