### PR TITLE
v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
+None.
+
+# 0.4.2 (May 8, 2021)
+
 - Correctly override `Body::size_hint` and `Body::is_end_stream` for `Empty`.
+- Add `Full` which is a body that consists of a single chunk.
 
 # 0.4.1 (March 18, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "http-body"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vx.y.z" git tag.
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   "Carl Lerche <me@carllerche.com>",
   "Lucio Franco <luciofranco14@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/http-body/0.4.1")]
+#![doc(html_root_url = "https://docs.rs/http-body/0.4.2")]
 #![deny(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.4.2 (May 8, 2021)

- Correctly override `Body::size_hint` and `Body::is_end_stream` for `Empty`.
- Add `Full` which is a body that consists of a single chunk.