### PR TITLE
Suggestion: Make `Full` and `Empty` work for any error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-None.
+- Make `Full` and `Empty` work for any error type.
 
 # 0.4.2 (May 8, 2021)
 

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -10,20 +10,20 @@ use std::{
 };
 
 /// A body that is always empty.
-pub struct Empty<D> {
-    _marker: PhantomData<fn() -> D>,
+pub struct Empty<D, E = Infallible> {
+    _marker: PhantomData<fn() -> (D, E)>,
 }
 
-impl<D> Empty<D> {
+impl<D, E> Empty<D, E> {
     /// Create a new `Empty`.
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<D: Buf> Body for Empty<D> {
+impl<D: Buf, E> Body for Empty<D, E> {
     type Data = D;
-    type Error = Infallible;
+    type Error = E;
 
     #[inline]
     fn poll_data(
@@ -50,13 +50,13 @@ impl<D: Buf> Body for Empty<D> {
     }
 }
 
-impl<D> fmt::Debug for Empty<D> {
+impl<D, E> fmt::Debug for Empty<D, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Empty").finish()
     }
 }
 
-impl<D> Default for Empty<D> {
+impl<D, E> Default for Empty<D, E> {
     fn default() -> Self {
         Self {
             _marker: PhantomData,
@@ -64,7 +64,7 @@ impl<D> Default for Empty<D> {
     }
 }
 
-impl<D> Clone for Empty<D> {
+impl<D, E> Clone for Empty<D, E> {
     fn clone(&self) -> Self {
         Self {
             _marker: PhantomData,
@@ -72,4 +72,4 @@ impl<D> Clone for Empty<D> {
     }
 }
 
-impl<D> Copy for Empty<D> {}
+impl<D, E> Copy for Empty<D, E> {}


### PR DESCRIPTION
**Note this is a breaking change 💥**

Having used `Empty` a few places in tonic and other places I've written
code this a few times:

```rust
http_body::Empty::new().map_err(|err| match err {}).boxed()
```

By default `Empty` uses `Infallible` as its error type so to use another
type you need to write `.map_err(|err| match err {})`. That gets a bit
tedious.

This makes `Empty` and `Full` generic over the error type as well which
removes that bit of boilerplate.