### PR TITLE
Implement `Default` for `BoxBody`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-None.
+- Implement `Default` for `BoxBody`.
 
 # 0.4.2 (May 8, 2021)
 

--- a/src/combinators/box_body.rs
+++ b/src/combinators/box_body.rs
@@ -59,3 +59,12 @@ where
         self.inner.size_hint()
     }
 }
+
+impl<D, E> Default for BoxBody<D, E>
+where
+    D: Buf + 'static,
+{
+    fn default() -> Self {
+        BoxBody::new(crate::Empty::new().map_err(|err| match err {}))
+    }
+}


### PR DESCRIPTION
This makes `BoxBody` usable with [`RequireAuthorization`] which requires `ResBody: Default`.

[`RequireAuthorization`]: https://docs.rs/tower-http/0.1.1/tower_http/auth/struct.RequireAuthorization.html