### PR TITLE
Add proper `Debug` impl for mapping combinators

### DIFF
--- a/src/combinators/map_data.rs
+++ b/src/combinators/map_data.rs
@@ -2,6 +2,8 @@ use crate::Body;
 use bytes::Buf;
 use pin_project_lite::pin_project;
 use std::{
+    any::type_name,
+    fmt,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -10,7 +12,7 @@ pin_project! {
     /// Body returned by the [`map_data`] combinator.
     ///
     /// [`map_data`]: crate::util::BodyExt::map_data
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy)]
     pub struct MapData<B, F> {
         #[pin]
         inner: B,
@@ -76,5 +78,17 @@ where
 
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
+    }
+}
+
+impl<B, F> fmt::Debug for MapData<B, F>
+where
+    B: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapData")
+            .field("inner", &self.inner)
+            .field("f", &type_name::<F>())
+            .finish()
     }
 }

--- a/src/combinators/map_err.rs
+++ b/src/combinators/map_err.rs
@@ -1,6 +1,8 @@
 use crate::Body;
 use pin_project_lite::pin_project;
 use std::{
+    any::type_name,
+    fmt,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -9,7 +11,7 @@ pin_project! {
     /// Body returned by the [`map_err`] combinator.
     ///
     /// [`map_err`]: crate::util::BodyExt::map_err
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Clone, Copy)]
     pub struct MapErr<B, F> {
         #[pin]
         inner: B,
@@ -79,5 +81,17 @@ where
 
     fn size_hint(&self) -> crate::SizeHint {
         self.inner.size_hint()
+    }
+}
+
+impl<B, F> fmt::Debug for MapErr<B, F>
+where
+    B: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapErr")
+            .field("inner", &self.inner)
+            .field("f", &type_name::<F>())
+            .finish()
     }
 }


### PR DESCRIPTION
Previously `#[derive(Debug)]` was used on the mapping structures. The structures consist of the original body and mapping fn, and since it's impossible to implement `Debug` for `Fn`, mapping structure were effectively never `Debug`.