### PR TITLE
Implement `From<BoxBody>` for `UnsyncBoxBody`

### DIFF
--- a/src/combinators/box_body.rs
+++ b/src/combinators/box_body.rs
@@ -132,3 +132,9 @@ where
         UnsyncBoxBody::new(crate::Empty::new().map_err(|err| match err {}))
     }
 }
+
+impl<D, E> From<BoxBody<D, E>> for UnsyncBoxBody<D, E> {
+    fn from(body: BoxBody<D, E>) -> Self {
+        Self { inner: body.inner }
+    }
+}


### PR DESCRIPTION
This can be useful for converting from one to the other without any extra unnecessary allocations.