### PR TITLE
Support for aggregating bodies into a Buf view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ categories = ["web-programming"]
 bytes = "1"
 http = "0.2"
 pin-project-lite = "0.2"
+pin-utils = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,0 +1,7 @@
+//! Adapters between [`Body`]s and other types.
+//!
+//! [`Body`]: crate::Body
+
+mod aggregate;
+
+pub use aggregate::aggregate;

--- a/src/adapters/aggregate.rs
+++ b/src/adapters/aggregate.rs
@@ -1,0 +1,31 @@
+use bytes::Buf;
+
+use crate::buf::BufList;
+use crate::Body;
+
+/// Aggregate the data buffers from a body asynchronously.
+///
+/// The returned `impl Buf` groups the `Buf`s from the `HttpBody` without
+/// copying them. This is ideal if you don't require a contiguous buffer.
+///
+/// # Note
+///
+/// Care needs to be taken if the remote is untrusted. The function doesn't implement any length
+/// checks and an malicious peer might make it consume arbitrary amounts of memory. Checking the
+/// `Content-Length` is a possibility, but it is not strictly mandated to be present.
+pub async fn aggregate<T>(body: T) -> Result<impl Buf, T::Error>
+where
+    T: Body,
+{
+    let mut bufs = BufList::new();
+
+    pin_utils::pin_mut!(body);
+    while let Some(buf) = body.data().await {
+        let buf = buf?;
+        if buf.has_remaining() {
+            bufs.push(buf);
+        }
+    }
+
+    Ok(bufs)
+}

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,0 +1,145 @@
+use std::collections::VecDeque;
+use std::io::IoSlice;
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+pub(crate) struct BufList<T> {
+    bufs: VecDeque<T>,
+}
+
+impl<T: Buf> BufList<T> {
+    pub(crate) fn new() -> BufList<T> {
+        BufList {
+            bufs: VecDeque::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn push(&mut self, buf: T) {
+        debug_assert!(buf.has_remaining());
+        self.bufs.push_back(buf);
+    }
+}
+
+impl<T: Buf> Buf for BufList<T> {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.bufs.iter().map(|buf| buf.remaining()).sum()
+    }
+
+    #[inline]
+    fn chunk(&self) -> &[u8] {
+        self.bufs.front().map(Buf::chunk).unwrap_or_default()
+    }
+
+    #[inline]
+    fn advance(&mut self, mut cnt: usize) {
+        while cnt > 0 {
+            {
+                let front = &mut self.bufs[0];
+                let rem = front.remaining();
+                if rem > cnt {
+                    front.advance(cnt);
+                    return;
+                } else {
+                    front.advance(rem);
+                    cnt -= rem;
+                }
+            }
+            self.bufs.pop_front();
+        }
+    }
+
+    #[inline]
+    fn chunks_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
+        if dst.is_empty() {
+            return 0;
+        }
+        let mut vecs = 0;
+        for buf in &self.bufs {
+            vecs += buf.chunks_vectored(&mut dst[vecs..]);
+            if vecs == dst.len() {
+                break;
+            }
+        }
+        vecs
+    }
+
+    #[inline]
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        // Our inner buffer may have an optimized version of copy_to_bytes, and if the whole
+        // request can be fulfilled by the front buffer, we can take advantage.
+        match self.bufs.front_mut() {
+            Some(front) if front.remaining() == len => {
+                let b = front.copy_to_bytes(len);
+                self.bufs.pop_front();
+                b
+            }
+            Some(front) if front.remaining() > len => front.copy_to_bytes(len),
+            _ => {
+                assert!(len <= self.remaining(), "`len` greater than remaining");
+                let mut bm = BytesMut::with_capacity(len);
+                bm.put(self.take(len));
+                bm.freeze()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+
+    use super::*;
+
+    fn hello_world_buf() -> BufList<Bytes> {
+        BufList {
+            bufs: vec![Bytes::from("Hello"), Bytes::from(" "), Bytes::from("World")].into(),
+        }
+    }
+
+    #[test]
+    fn to_bytes_shorter() {
+        let mut bufs = hello_world_buf();
+        let old_ptr = bufs.chunk().as_ptr();
+        let start = bufs.copy_to_bytes(4);
+        assert_eq!(start, "Hell");
+        assert!(ptr::eq(old_ptr, start.as_ptr()));
+        assert_eq!(bufs.chunk(), b"o");
+        assert!(ptr::eq(old_ptr.wrapping_add(4), bufs.chunk().as_ptr()));
+        assert_eq!(bufs.remaining(), 7);
+    }
+
+    #[test]
+    fn to_bytes_eq() {
+        let mut bufs = hello_world_buf();
+        let old_ptr = bufs.chunk().as_ptr();
+        let start = bufs.copy_to_bytes(5);
+        assert_eq!(start, "Hello");
+        assert!(ptr::eq(old_ptr, start.as_ptr()));
+        assert_eq!(bufs.chunk(), b" ");
+        assert_eq!(bufs.remaining(), 6);
+    }
+
+    #[test]
+    fn to_bytes_longer() {
+        let mut bufs = hello_world_buf();
+        let start = bufs.copy_to_bytes(7);
+        assert_eq!(start, "Hello W");
+        assert_eq!(bufs.remaining(), 4);
+    }
+
+    #[test]
+    fn one_long_buf_to_bytes() {
+        let mut buf = BufList::new();
+        buf.push(b"Hello World" as &[_]);
+        assert_eq!(buf.copy_to_bytes(5), "Hello");
+        assert_eq!(buf.chunk(), b" World");
+    }
+
+    #[test]
+    #[should_panic(expected = "`len` greater than remaining")]
+    fn buf_to_bytes_too_many() {
+        hello_world_buf().copy_to_bytes(42);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,13 @@
 //!
 //! [`Body`]: trait.Body.html
 
+mod buf;
 mod empty;
 mod full;
 mod next;
 mod size_hint;
 
+pub mod adapters;
 pub mod combinators;
 
 pub use self::empty::Empty;


### PR DESCRIPTION
`http_body::adapters::aggregate` is an async function that accumulates
body chunks without moving them, once fully ready body data can be
accessed as a single Buf.

Taken from hyper with no changes.

Does not implement limits on body size, the future will not be resolved
as long as the underlying body implementation (and any remote end) are
willing to provide more data.

Motivation: this is useful outside hyper, and does not depend on any particular implementation of the trait.

The underlying BufList struct is also used in hyper for http1 connexion write buffers, but I chose not to make it public API.  It's short enough that I don't think duplication matters; if others find it useful it might be shared through the bytes crate.