### PR TITLE
Add String impl for body

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,14 @@ impl Body for String {
     ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
         Poll::Ready(Ok(None))
     }
+
+    fn is_end_stream(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(self.len() as u64)
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,8 @@ pub use self::next::{Data, Trailers};
 pub use self::size_hint::SizeHint;
 
 use self::combinators::{BoxBody, MapData, MapErr, UnsyncBoxBody};
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use http::HeaderMap;
-use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::ops;
 use std::pin::Pin;
@@ -286,7 +285,7 @@ impl<B: Body> Body for http::Response<B> {
 }
 
 impl Body for String {
-    type Data = VecDeque<u8>;
+    type Data = Bytes;
     type Error = Infallible;
 
     fn poll_data(


### PR DESCRIPTION
Closes #57

This PR adds a `impl Body for String` to allow users to provide more ergonomic APIs that can support simple use case like passing a string. This PR does not add support for `&str` or `Cow<'a, str>` since neither of these pass an owned and thus mutable "buffer" view that can be used to track if we've returned the data in `poll_data` already.

cc @nmoutschen