### PR TITLE
chore: Prepare `0.4.5` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 None.
 
+# 0.4.5 (May 20, 2022)
+
+- Add `String` impl for `Body`.
+- Add `Limited` body implementation.
+
 # 0.4.4 (October 22, 2021)
 
 - Add `UnsyncBoxBody` and `Body::boxed_unsync`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "http-body"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "vx.y.z" git tag.
-version = "0.4.4"
+version = "0.4.5"
 authors = [
   "Carl Lerche <me@carllerche.com>",
   "Lucio Franco <luciofranco14@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/http-body/0.4.4")]
+#![doc(html_root_url = "https://docs.rs/http-body/0.4.5")]
 #![deny(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.4.5 (May 20, 2022)

- Add `String` impl for `Body`.
- Add `Limited` body implementation.