### PR TITLE
http-body-util: fix Collect if a poll is not ready immediately

### DIFF
--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -82,7 +82,10 @@ pub trait BodyExt: http_body::Body {
     where
         Self: Sized,
     {
-        combinators::Collect { body: self }
+        combinators::Collect {
+            body: self,
+            collected: Some(crate::Collected::default()),
+        }
     }
 }
 


### PR DESCRIPTION
I noticed in some hyper tests if the body wasn't available immediately, some data was being lost. Eventually noticed it's because the buf list wasn't persisted between polls 🙃 