### PR TITLE
util: Fix futures-util allowed version range.

### DIFF
--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["web-programming"]
 
 [dependencies]
 bytes = "1"
-futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.14", default-features = false, features = ["alloc"] }
 http = "0.2"
 http-body = { version = "=1.0.0-rc.2", path = "../http-body" }
 pin-project-lite = "0.2"


### PR DESCRIPTION
This should potentially be a stricter range, since futures-util doesn't follow semver, but I'm leaving this at the most permissive thing that doesn't currently result in broken builds, since I don't know this project's stance on dependency versioning.

Fixes: #83