### PR TITLE
Make `Full` and `Empty` generic over the error type

### DIFF
--- a/http-body-util/src/collected.rs
+++ b/http-body-util/src/collected.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_body() {
-        let body = Full::new(&b"hello"[..]);
+        let body = Full::<_, Infallible>::new(&b"hello"[..]);
 
         let buffered = body.collect().await.unwrap();
 
@@ -121,6 +121,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(unused_must_use)]
     async fn delayed_segments() {
         let one = stream::once(async { Ok::<_, Infallible>(Frame::data(&b"hello "[..])) });
         let two = stream::once(async {

--- a/http-body-util/src/combinators/box_body.rs
+++ b/http-body-util/src/combinators/box_body.rs
@@ -1,5 +1,3 @@
-use crate::BodyExt as _;
-
 use bytes::Buf;
 use http_body::{Body, Frame, SizeHint};
 use std::{
@@ -63,9 +61,10 @@ where
 impl<D, E> Default for BoxBody<D, E>
 where
     D: Buf + 'static,
+    E: 'static,
 {
     fn default() -> Self {
-        BoxBody::new(crate::Empty::new().map_err(|err| match err {}))
+        BoxBody::new(crate::Empty::new())
     }
 }
 
@@ -115,8 +114,9 @@ where
 impl<D, E> Default for UnsyncBoxBody<D, E>
 where
     D: Buf + 'static,
+    E: 'static,
 {
     fn default() -> Self {
-        UnsyncBoxBody::new(crate::Empty::new().map_err(|err| match err {}))
+        UnsyncBoxBody::new(crate::Empty::new())
     }
 }

--- a/http-body-util/src/either.rs
+++ b/http-body-util/src/either.rs
@@ -144,14 +144,16 @@ pub(crate) mod proj {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
     use super::*;
-    use crate::{BodyExt, Empty, Full};
+    use crate::{Empty, Full, BodyExt};
 
     #[tokio::test]
     async fn data_left() {
-        let full = Full::new(&b"hello"[..]);
+        let full = Full::<_, Infallible>::new(&b"hello"[..]);
 
-        let mut value: Either<_, Empty<&[u8]>> = Either::Left(full);
+        let mut value: Either<_, Empty<&[u8], Infallible>> = Either::Left(full);
 
         assert_eq!(value.size_hint().exact(), Some(b"hello".len() as u64));
         assert_eq!(
@@ -163,9 +165,9 @@ mod tests {
 
     #[tokio::test]
     async fn data_right() {
-        let full = Full::new(&b"hello!"[..]);
+        let full = Full::<_, Infallible>::new(&b"hello!"[..]);
 
-        let mut value: Either<Empty<&[u8]>, _> = Either::Right(full);
+        let mut value: Either<Empty<&[u8], Infallible>, _> = Either::Right(full);
 
         assert_eq!(value.size_hint().exact(), Some(b"hello!".len() as u64));
         assert_eq!(

--- a/http-body-util/src/either.rs
+++ b/http-body-util/src/either.rs
@@ -147,7 +147,7 @@ mod tests {
     use std::convert::Infallible;
 
     use super::*;
-    use crate::{Empty, Full, BodyExt};
+    use crate::{BodyExt, Empty, Full};
 
     #[tokio::test]
     async fn data_left() {

--- a/http-body-util/src/empty.rs
+++ b/http-body-util/src/empty.rs
@@ -1,7 +1,6 @@
 use bytes::Buf;
 use http_body::{Body, Frame, SizeHint};
 use std::{
-    convert::Infallible,
     fmt,
     marker::PhantomData,
     pin::Pin,
@@ -9,20 +8,20 @@ use std::{
 };
 
 /// A body that is always empty.
-pub struct Empty<D> {
-    _marker: PhantomData<fn() -> D>,
+pub struct Empty<D, E> {
+    _marker: PhantomData<fn() -> (D, E)>,
 }
 
-impl<D> Empty<D> {
+impl<D, E> Empty<D, E> {
     /// Create a new `Empty`.
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<D: Buf> Body for Empty<D> {
+impl<D: Buf, E> Body for Empty<D, E> {
     type Data = D;
-    type Error = Infallible;
+    type Error = E;
 
     #[inline]
     fn poll_frame(
@@ -41,13 +40,13 @@ impl<D: Buf> Body for Empty<D> {
     }
 }
 
-impl<D> fmt::Debug for Empty<D> {
+impl<D, E> fmt::Debug for Empty<D, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Empty").finish()
     }
 }
 
-impl<D> Default for Empty<D> {
+impl<D, E> Default for Empty<D, E> {
     fn default() -> Self {
         Self {
             _marker: PhantomData,
@@ -55,7 +54,7 @@ impl<D> Default for Empty<D> {
     }
 }
 
-impl<D> Clone for Empty<D> {
+impl<D, E> Clone for Empty<D, E> {
     fn clone(&self) -> Self {
         Self {
             _marker: PhantomData,
@@ -63,4 +62,4 @@ impl<D> Clone for Empty<D> {
     }
 }
 
-impl<D> Copy for Empty<D> {}
+impl<D, E> Copy for Empty<D, E> {}

--- a/http-body-util/src/empty.rs
+++ b/http-body-util/src/empty.rs
@@ -1,6 +1,7 @@
 use bytes::Buf;
 use http_body::{Body, Frame, SizeHint};
 use std::{
+    convert::Infallible,
     fmt,
     marker::PhantomData,
     pin::Pin,
@@ -8,7 +9,7 @@ use std::{
 };
 
 /// A body that is always empty.
-pub struct Empty<D, E> {
+pub struct Empty<D, E = Infallible> {
     _marker: PhantomData<fn() -> (D, E)>,
 }
 

--- a/http-body-util/src/full.rs
+++ b/http-body-util/src/full.rs
@@ -89,7 +89,10 @@ where
 {
     /// Create an empty `Full`.
     fn default() -> Self {
-        Full { data: None, _marker: PhantomData }
+        Full {
+            data: None,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/http-body-util/src/full.rs
+++ b/http-body-util/src/full.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, Bytes};
 use http_body::{Body, Frame, SizeHint};
 use pin_project_lite::pin_project;
 use std::borrow::Cow;
-use std::convert::TryFrom;
+use std::convert::{Infallible, TryFrom};
 use std::fmt;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 
 pin_project! {
     /// A body that consists of a single chunk.
-    pub struct Full<D, E> {
+    pub struct Full<D, E = Infallible> {
         data: Option<D>,
         _marker: PhantomData<fn() -> E>,
     }

--- a/http-body-util/src/full.rs
+++ b/http-body-util/src/full.rs
@@ -2,19 +2,21 @@ use bytes::{Buf, Bytes};
 use http_body::{Body, Frame, SizeHint};
 use pin_project_lite::pin_project;
 use std::borrow::Cow;
-use std::convert::{Infallible, TryFrom};
+use std::convert::TryFrom;
+use std::fmt;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 pin_project! {
     /// A body that consists of a single chunk.
-    #[derive(Clone, Copy, Debug)]
-    pub struct Full<D> {
+    pub struct Full<D, E> {
         data: Option<D>,
+        _marker: PhantomData<fn() -> E>,
     }
 }
 
-impl<D> Full<D>
+impl<D, E> Full<D, E>
 where
     D: Buf,
 {
@@ -25,16 +27,19 @@ where
         } else {
             None
         };
-        Full { data }
+        Full {
+            data,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<D> Body for Full<D>
+impl<D, E> Body for Full<D, E>
 where
     D: Buf,
 {
     type Data = D;
-    type Error = Infallible;
+    type Error = E;
 
     fn poll_frame(
         mut self: Pin<&mut Self>,
@@ -55,17 +60,40 @@ where
     }
 }
 
-impl<D> Default for Full<D>
+impl<D, E> Clone for Full<D, E>
+where
+    D: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<D, E> Copy for Full<D, E> where D: Copy {}
+
+impl<D, E> fmt::Debug for Full<D, E>
+where
+    D: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Full").field("data", &self.data).finish()
+    }
+}
+
+impl<D, E> Default for Full<D, E>
 where
     D: Buf,
 {
     /// Create an empty `Full`.
     fn default() -> Self {
-        Full { data: None }
+        Full { data: None, _marker: PhantomData }
     }
 }
 
-impl<D> From<Bytes> for Full<D>
+impl<D, E> From<Bytes> for Full<D, E>
 where
     D: Buf + From<Bytes>,
 {
@@ -74,7 +102,7 @@ where
     }
 }
 
-impl<D> From<Vec<u8>> for Full<D>
+impl<D, E> From<Vec<u8>> for Full<D, E>
 where
     D: Buf + From<Vec<u8>>,
 {
@@ -83,7 +111,7 @@ where
     }
 }
 
-impl<D> From<&'static [u8]> for Full<D>
+impl<D, E> From<&'static [u8]> for Full<D, E>
 where
     D: Buf + From<&'static [u8]>,
 {
@@ -92,7 +120,7 @@ where
     }
 }
 
-impl<D, B> From<Cow<'static, B>> for Full<D>
+impl<D, E, B> From<Cow<'static, B>> for Full<D, E>
 where
     D: Buf + From<&'static B> + From<B::Owned>,
     B: ToOwned + ?Sized,
@@ -105,7 +133,7 @@ where
     }
 }
 
-impl<D> From<String> for Full<D>
+impl<D, E> From<String> for Full<D, E>
 where
     D: Buf + From<String>,
 {
@@ -114,7 +142,7 @@ where
     }
 }
 
-impl<D> From<&'static str> for Full<D>
+impl<D, E> From<&'static str> for Full<D, E>
 where
     D: Buf + From<&'static str>,
 {
@@ -125,12 +153,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
     use super::*;
     use crate::BodyExt;
 
     #[tokio::test]
     async fn full_returns_some() {
-        let mut full = Full::new(&b"hello"[..]);
+        let mut full = Full::<_, Infallible>::new(&b"hello"[..]);
         assert_eq!(full.size_hint().exact(), Some(b"hello".len() as u64));
         assert_eq!(
             full.frame().await.unwrap().unwrap().into_data().unwrap(),
@@ -141,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_full_returns_none() {
-        assert!(Full::<&[u8]>::default().frame().await.is_none());
-        assert!(Full::new(&b""[..]).frame().await.is_none());
+        assert!(Full::<&[u8], Infallible>::default().frame().await.is_none());
+        assert!(Full::<_, Infallible>::new(&b""[..]).frame().await.is_none());
     }
 }

--- a/http-body-util/src/limited.rs
+++ b/http-body-util/src/limited.rs
@@ -110,7 +110,7 @@ mod tests {
     #[tokio::test]
     async fn read_for_body_under_limit_returns_data() {
         const DATA: &[u8] = b"testing";
-        let inner = Full::new(Bytes::from(DATA));
+        let inner = Full::<_, Infallible>::new(Bytes::from(DATA));
         let body = &mut Limited::new(inner, 8);
 
         let mut hint = SizeHint::new();
@@ -128,7 +128,7 @@ mod tests {
     #[tokio::test]
     async fn read_for_body_over_limit_returns_error() {
         const DATA: &[u8] = b"testing a string that is too long";
-        let inner = Full::new(Bytes::from(DATA));
+        let inner = Full::<_, Infallible>::new(Bytes::from(DATA));
         let body = &mut Limited::new(inner, 8);
 
         let mut hint = SizeHint::new();

--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -42,6 +42,7 @@ pub trait Body {
     type Error;
 
     /// Attempt to pull out the next data buffer of this stream.
+    #[allow(clippy::type_complexity)]
     fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
It is not uncommon to have a function that creatures a boxed body via `Full` or `Empty`:

```rust
fn box_body_from_bytes(bytes: Bytes) -> UnsyncBoxBody<Bytes, Error> {
    Full::new(bytes)
        .map_err(|e| match e {})
        .boxed_unsync()
}
```

The `.map_err(|e| match e {})` dance is necessary because `Full` always uses `Infallible` as its error type, so we have to convert that into whatever error type we actually need. This will often be hyper's, tonic's, or axum's error type.

However if we make `Full` generic over the error type:

```rust
pub struct Full<D, E> { ... }
```

then Rust can just infer it and we avoid having to call `map_err`:

```rust
fn box_body_from_bytes(bytes: Bytes) -> UnsyncBoxBody<Bytes, Error> {
    Full::new(bytes).boxed_unsync()
}
```

I think this is quite a bit nicer. It is especially nice that we avoid having to type `match e {}` which is quite confusing unless you've see it before.

The downside to this is that if the error type cannot be infered you have to explicitly set it when creating a `Full`:

```rust
Full::<_, Error>::new(bytes)
```

That makes this a breaking change.