### PR TITLE
Add BodyStream.

### DIFF
--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::either::Either;
 pub use self::empty::Empty;
 pub use self::full::Full;
 pub use self::limited::{LengthLimitError, Limited};
-pub use self::stream::StreamBody;
+pub use self::stream::{BodyStream, StreamBody};
 
 /// An extension trait for [`http_body::Body`] adding various combinators and adapters
 pub trait BodyExt: http_body::Body {


### PR DESCRIPTION
This PR adds a `BodyStream` type to create a `Stream` from a `Body`. This is useful when you want to stream data from a `Body` to code that accepts a `Stream`.