### PR TITLE
perf(util): optimize `<BufList as Buf>::has_remaining`

### DIFF
--- a/http-body-util/src/util.rs
+++ b/http-body-util/src/util.rs
@@ -28,6 +28,11 @@ impl<T: Buf> Buf for BufList<T> {
     }
 
     #[inline]
+    fn has_remaining(&self) -> bool {
+        self.bufs.iter().any(|buf| buf.has_remaining())
+    }
+
+    #[inline]
     fn chunk(&self) -> &[u8] {
         self.bufs.front().map(Buf::chunk).unwrap_or_default()
     }


### PR DESCRIPTION
This allows short-circuiting when there is a non-empty chunk.