### PR TITLE
util: replace futures-util with futures-core

### DIFF
--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -27,10 +27,11 @@ categories = ["web-programming"]
 
 [dependencies]
 bytes = "1"
-futures-util = { version = "0.3.14", default-features = false, features = ["alloc"] }
+futures-core = "0.3"
 http = "1"
 http-body = { version = "1", path = "../http-body" }
 pin-project-lite = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "sync", "rt-multi-thread"] }
+futures-util = { version = "0.3.14", default-features = false }

--- a/http-body-util/src/combinators/collect.rs
+++ b/http-body-util/src/combinators/collect.rs
@@ -1,9 +1,9 @@
 use std::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use futures_util::Future;
 use http_body::Body;
 use pin_project_lite::pin_project;
 
@@ -29,7 +29,7 @@ impl<T: Body + ?Sized> Future for Collect<T> {
         let mut me = self.project();
 
         loop {
-            let frame = futures_util::ready!(me.body.as_mut().poll_frame(cx));
+            let frame = futures_core::ready!(me.body.as_mut().poll_frame(cx));
 
             let frame = if let Some(frame) = frame {
                 frame?

--- a/http-body-util/src/combinators/with_trailers.rs
+++ b/http-body-util/src/combinators/with_trailers.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::ready;
+use futures_core::ready;
 use http::HeaderMap;
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;

--- a/http-body-util/src/stream.rs
+++ b/http-body-util/src/stream.rs
@@ -1,5 +1,5 @@
 use bytes::Buf;
-use futures_util::stream::Stream;
+use futures_core::Stream;
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;
 use std::{


### PR DESCRIPTION
As `futures-util` is used only in the test, `http-body-util` seems to be able to use `futures-core` instead of `futures-util` in the dependencies.