### PR TITLE
chore: set msrv to 1.49

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,3 +49,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features
+
+  doc:
+    needs: [style]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo doc --no-deps
+        env:
+          RUSTDOCFLAGS: -D rustdoc::broken-intra-doc-links

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+  msrv:
+    needs: [style]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack --rust-version --no-dev-deps check
+
   minimal-versions:
     needs: [style]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,2 @@
 [workspace]
 members = ["http-body", "http-body-util"]
-resolver = "2"

--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -24,6 +24,7 @@ Combinators and adapters for HTTP request or response bodies.
 """
 keywords = ["http"]
 categories = ["web-programming"]
+rust-version = "1.49"
 
 [dependencies]
 bytes = "1"

--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    missing_debug_implementations,
-    missing_docs,
-    unreachable_pub,
-    rustdoc::broken_intra_doc_links
-)]
+#![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Utilities for [`http_body::Body`].

--- a/http-body/Cargo.toml
+++ b/http-body/Cargo.toml
@@ -23,6 +23,7 @@ Trait representing an asynchronous, streaming, HTTP request or response body.
 """
 keywords = ["http"]
 categories = ["web-programming"]
+rust-version = "1.49"
 
 [dependencies]
 bytes = "1"

--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -2,7 +2,6 @@
     missing_debug_implementations,
     missing_docs,
     unreachable_pub,
-    rustdoc::broken_intra_doc_links,
     clippy::missing_safety_doc,
     clippy::undocumented_unsafe_blocks
 )]


### PR DESCRIPTION
Sets `http-body` and `http-body-util`'s msrv to 1.49 the max version of each dependency.