### PR TITLE
perf: improve BufList::copy_to_bytes if len == remaining

### DIFF
--- a/http-body-util/src/util.rs
+++ b/http-body-util/src/util.rs
@@ -82,9 +82,15 @@ impl<T: Buf> Buf for BufList<T> {
             }
             Some(front) if front.remaining() > len => front.copy_to_bytes(len),
             _ => {
-                assert!(len <= self.remaining(), "`len` greater than remaining");
+                let rem = self.remaining();
+                assert!(len <= rem, "`len` greater than remaining");
                 let mut bm = BytesMut::with_capacity(len);
-                bm.put(self.take(len));
+                if rem == len {
+                    // .take() costs a lot more, so skip it if we don't need it
+                    bm.put(self);
+                } else {
+                    bm.put(self.take(len));
+                }
                 bm.freeze()
             }
         }


### PR DESCRIPTION
Using `take(len)` costs a bit in performance. If copying the full thing (which is what `Collected::to_bytes()` does), we can skip using `take(n)` and see a significant speed up.

Using hyper's body benchmarks, on my tiny VM, the perf improvement is from 5GB/s to 31GB/s.