### PR TITLE
refactor: replace deprecated std::u64 with primitive type

### DIFF
--- a/http-body/src/size_hint.rs
+++ b/http-body/src/size_hint.rs
@@ -1,5 +1,3 @@
-use std::u64;
-
 /// A `Body` size hint
 ///
 /// The default implementation returns:


### PR DESCRIPTION
Replaces deprecated `std::u64` with the corresponding primitive type.

https://doc.rust-lang.org/std/u64/index.html