### PR TITLE
Backport to_bytes performance optimizations

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -154,6 +154,11 @@ impl<T: Buf> Buf for BufList<T> {
     }
 
     #[inline]
+    fn has_remaining(&self) -> bool {
+        self.bufs.iter().any(|buf| buf.has_remaining())
+    }
+
+    #[inline]
     fn chunk(&self) -> &[u8] {
         self.bufs.front().map(Buf::chunk).unwrap_or_default()
     }


### PR DESCRIPTION
Backports https://github.com/hyperium/http-body/pull/94 and https://github.com/hyperium/http-body/pull/112.

We had some performance issues and found out that `to_bytes()` has a quadratic complexity with respect to the number of chunks in the BufList (in our case it was taking 10 minutes to run `to_bytes` on a ~65MB body). This has been already fixed in `1.x`, but `0.4.x` seems to be still widely used, so it would be nice to have this fix there as well.

