### PR TITLE
feat(util): add `BodyExt::limited`

### DIFF
--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -100,6 +100,14 @@ pub trait BodyExt: http_body::Body {
         UnsyncBoxBody::new(self)
     }
 
+    /// Turn this body into a [`Limited`] body with the given limit.
+    fn limited(self, limit: usize) -> Limited<Self>
+    where
+        Self: Sized,
+    {
+        Limited::new(self, limit)
+    }
+
     /// Turn this body into [`Collected`] body which will collect all the DATA frames
     /// and trailers.
     fn collect(self) -> combinators::Collect<Self>


### PR DESCRIPTION
According to https://github.com/hyperium/hyper/issues/3111#issuecomment-1379585720 and https://github.com/hyperium/hyper/issues/3111#issuecomment-1901058988, it seems that the `BodyExt` trait is supposed to have a `limit()` method.

I couldn't find it, so I opened this PR. I also slightly changed its name to `limited` to maintain consistency with methods like `boxed`.