### PR TITLE
chore(util): update msrv to 1.61

### DIFF
--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -24,7 +24,7 @@ Combinators and adapters for HTTP request or response bodies.
 """
 keywords = ["http"]
 categories = ["web-programming"]
-rust-version = "1.56"
+rust-version = "1.61"
 
 [dependencies]
 bytes = "1"


### PR DESCRIPTION
Proposes to update `http-body-util`'s MSRV to 1.61 to use https://github.com/rust-lang/rust/pull/93827/.