### PR TITLE
http-body-util: minor doc and lint fixes, raising msrv to 1.56

### DIFF
--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -24,7 +24,7 @@ Combinators and adapters for HTTP request or response bodies.
 """
 keywords = ["http"]
 categories = ["web-programming"]
-rust-version = "1.49"
+rust-version = "1.56"
 
 [dependencies]
 bytes = "1"

--- a/http-body-util/src/combinators/box_body.rs
+++ b/http-body-util/src/combinators/box_body.rs
@@ -71,7 +71,7 @@ where
 
 // === UnsyncBoxBody ===
 impl<D, E> UnsyncBoxBody<D, E> {
-    /// Create a new `BoxBody`.
+    /// Create a new `UnsyncBoxBody`.
     pub fn new<B>(body: B) -> Self
     where
         B: Body<Data = D, Error = E> + Send + 'static,

--- a/http-body-util/src/combinators/frame.rs
+++ b/http-body-util/src/combinators/frame.rs
@@ -9,7 +9,7 @@ use core::task;
 /// Future that resolves to the next frame from a [`Body`].
 pub struct Frame<'a, T: ?Sized>(pub(crate) &'a mut T);
 
-impl<'a, T: Body + Unpin + ?Sized> Future for Frame<'a, T> {
+impl<T: Body + Unpin + ?Sized> Future for Frame<'_, T> {
     type Output = Option<Result<http_body::Frame<T::Data>, T::Error>>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> task::Poll<Self::Output> {


### PR DESCRIPTION
It claimed `UnsyncBoxBody::new` creates a `BoxBody`. Not the end of the world, but still!