### PR TITLE
Replace futures-util with futures-core in non-test code

### DIFF
--- a/http-body-util/Cargo.toml
+++ b/http-body-util/Cargo.toml
@@ -28,10 +28,11 @@ rust-version = "1.56"
 
 [dependencies]
 bytes = "1"
-futures-util = { version = "0.3", default-features = false }
+futures-core = { version = "0.3", default-features = false }
 http = "1"
 http-body = { version = "1", path = "../http-body" }
 pin-project-lite = "0.2"
 
 [dev-dependencies]
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["macros", "rt", "sync", "rt-multi-thread"] }

--- a/http-body-util/src/combinators/collect.rs
+++ b/http-body-util/src/combinators/collect.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use futures_core::ready;
 use http_body::Body;
 use pin_project_lite::pin_project;
 
@@ -29,7 +30,7 @@ impl<T: Body + ?Sized> Future for Collect<T> {
         let mut me = self.project();
 
         loop {
-            let frame = futures_util::ready!(me.body.as_mut().poll_frame(cx));
+            let frame = ready!(me.body.as_mut().poll_frame(cx));
 
             let frame = if let Some(frame) = frame {
                 frame?

--- a/http-body-util/src/combinators/with_trailers.rs
+++ b/http-body-util/src/combinators/with_trailers.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::ready;
+use futures_core::ready;
 use http::HeaderMap;
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;

--- a/http-body-util/src/stream.rs
+++ b/http-body-util/src/stream.rs
@@ -1,5 +1,5 @@
 use bytes::Buf;
-use futures_util::{ready, stream::Stream};
+use futures_core::{ready, stream::Stream};
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;
 use std::{


### PR DESCRIPTION
No need to depend on the bigger crate.

While most crates using this (in combination with hyper and/or tower) are likely still going to depend on `futures-util` for a long time anyways, this potentially improves build pipelining a little bit, allowing the two util crates to be built in parallel.