### PR TITLE
ci: make a final ci-is-green job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,20 @@ on:
       - master
 
 jobs:
+  ci-pass:
+    name: CI is green
+    runs-on: ubuntu-latest
+    needs:
+      - style
+      - test
+      - msrv
+      - minimal-versions
+      - clippy
+      - doc
+    steps:
+      - run: exit 0
+
+
   style:
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +65,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-minimal-versions
       - run: cargo minimal-versions check
 
-  clippy_check:
+  clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is similar to our other repos, that way we can set branch protections to just care about "CI is green", and new jobs can be added in this file only.