### PR TITLE
chore(http-body): update msrv to 1.61

### DIFF
--- a/http-body/Cargo.toml
+++ b/http-body/Cargo.toml
@@ -23,7 +23,7 @@ Trait representing an asynchronous, streaming, HTTP request or response body.
 """
 keywords = ["http"]
 categories = ["web-programming"]
-rust-version = "1.49"
+rust-version = "1.61"
 
 [dependencies]
 bytes = "1"


### PR DESCRIPTION
this commit updates the MSRV of the `http-body` crate to 1.61.

this brings the `http-body` crate into step with the MSRV of the `http-body-util` crate.

in #128, the MSRV of the `http-body-util` crate was update to 1.61. however, compiling a crate in practice requires being able to parse all of the package manifests in its workspace. this means that using more recent features, like `dep:` syntax for optional dependencies included via cargo features, will not work due to the older `1.49` toolchain supported by `http-body`.

see the rust reference, here:
<https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>

see #140, which depends on this commit.