### PR TITLE
docs: notes on poll_frame return values

### DIFF
--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -43,7 +43,7 @@ pub trait Body {
     type Error;
 
     #[allow(clippy::type_complexity)]
-    /// Attempt to pull out the next data buffer of this stream.
+    /// Attempt to pull out the next frame of this stream.
     ///
     /// # Return value
     ///

--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -44,6 +44,21 @@ pub trait Body {
 
     #[allow(clippy::type_complexity)]
     /// Attempt to pull out the next data buffer of this stream.
+    ///
+    /// # Return value
+    ///
+    /// This function returns:
+    ///
+    /// - [`Poll::Pending`] if the next frame is not ready yet.
+    /// - [`Poll::Ready(Some(Ok(frame)))`] when the next frame is available.
+    /// - [`Poll::Ready(Some(Err(error)))`] when an error has been reached.
+    /// - [`Poll::Ready(None)`] means that all of the frames in this stream have been returned, and
+    ///   that the end of the stream has been reached.
+    ///
+    /// If [`Poll::Ready(Some(Err(error)))`] is returned, this body should be discarded.
+    ///
+    /// Once the end of the stream is reached, implementations should continue to return
+    /// [`Poll::Ready(None)`].
     fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
this commit introduces some additional documentation for `Body::poll_frame(..)`.

this adds some explicit information about what different return values indicate, and how callers are expected to respond to particular outcomes. these docs are modeled after the equivalent sections in the documentation of [`Stream`](https://docs.rs/futures-core/0.3.31/futures_core/stream/trait.Stream.html#return-value) and [`Future`](https://doc.rust-lang.org/stable/std/future/trait.Future.html#return-value).