### PR TITLE
feat(util): add ResponseExt trait

### DIFF
--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -13,6 +13,7 @@ mod either;
 mod empty;
 mod full;
 mod limited;
+mod response_ext;
 mod stream;
 
 #[cfg(feature = "channel")]
@@ -22,15 +23,15 @@ mod util;
 
 use self::combinators::{BoxBody, MapErr, MapFrame, UnsyncBoxBody};
 
+#[cfg(feature = "channel")]
+pub use self::channel::Channel;
 pub use self::collected::Collected;
 pub use self::either::Either;
 pub use self::empty::Empty;
 pub use self::full::Full;
 pub use self::limited::{LengthLimitError, Limited};
+pub use self::response_ext::ResponseExt;
 pub use self::stream::{BodyDataStream, BodyStream, StreamBody};
-
-#[cfg(feature = "channel")]
-pub use self::channel::Channel;
 
 /// An extension trait for [`http_body::Body`] adding various combinators and adapters
 pub trait BodyExt: http_body::Body {

--- a/http-body-util/src/response_ext.rs
+++ b/http-body-util/src/response_ext.rs
@@ -1,0 +1,116 @@
+use crate::combinators::{BoxBody, UnsyncBoxBody};
+
+/// An extension trait for [`http::Request`] adding various combinators and adapters
+pub trait ResponseExt<B> {
+    /// Returns a new `http::Response` with the body boxed.
+    ///
+    /// This is useful when you have need to return a Response where the body type is not known at
+    /// compile time.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bytes::Bytes;
+    /// use http::Response;
+    /// use http_body_util::{Empty, ResponseExt};
+    ///
+    /// # let some_condition = true;
+    /// let response = if some_condition {
+    ///     greeting().box_body()
+    /// } else {
+    ///     empty().box_body()
+    /// };
+    ///
+    /// fn greeting() -> Response<String> {
+    ///     Response::new("Hello, World!".to_string())
+    /// }
+    ///
+    /// fn empty() -> Response<Empty<Bytes>> {
+    ///     Response::new(Empty::new())
+    /// }
+    /// ```
+    fn box_body(self) -> http::Response<BoxBody<B::Data, B::Error>>
+    where
+        B: http_body::Body + Send + Sync + 'static;
+
+    /// Returns a new `http::Response` with the body boxed and !Sync.
+    ///
+    /// This is useful when you have need to return a Response where the body type is not known at
+    /// compile time and the body is not Sync.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bytes::Bytes;
+    /// use http::Response;
+    /// use http_body_util::{Empty, ResponseExt};
+    ///
+    /// # let some_condition = true;
+    /// let response = if some_condition {
+    ///     greeting().box_body_unsync()
+    /// } else {
+    ///     empty().box_body_unsync()
+    /// };
+    ///
+    /// fn greeting() -> Response<String> {
+    ///     Response::new("Hello, World!".to_string())
+    /// }
+    ///
+    /// fn empty() -> Response<Empty<Bytes>> {
+    ///     Response::new(Empty::new())
+    /// }
+    /// ```
+    fn box_body_unsync(self) -> http::Response<UnsyncBoxBody<B::Data, B::Error>>
+    where
+        B: http_body::Body + Send + 'static;
+}
+
+impl<B> ResponseExt<B> for http::Response<B> {
+    fn box_body(self) -> http::Response<BoxBody<B::Data, B::Error>>
+    where
+        B: http_body::Body + Send + Sync + 'static,
+    {
+        self.map(crate::BodyExt::boxed)
+    }
+
+    fn box_body_unsync(self) -> http::Response<UnsyncBoxBody<B::Data, B::Error>>
+    where
+        B: http_body::Body + Send + 'static,
+    {
+        self.map(crate::BodyExt::boxed_unsync)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http::{Response, StatusCode, Uri};
+
+    use super::*;
+    use crate::{Empty, Full};
+
+    #[test]
+    fn box_body() {
+        let uri: Uri = "http://example.com".parse().unwrap();
+        let _response = match uri.path() {
+            "/greeting" => greeting().box_body(),
+            "/empty" => empty().box_body(),
+            _ => not_found().box_body(),
+        };
+    }
+
+    fn greeting() -> Response<String> {
+        Response::new("Hello, World!".to_string())
+    }
+
+    fn empty() -> Response<Empty<Bytes>> {
+        Response::new(Empty::new())
+    }
+
+    fn not_found() -> Response<Full<Bytes>> {
+        Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body("Not Found".into())
+            .unwrap()
+    }
+}


### PR DESCRIPTION
This adds a `ResponseExt` trait to the `http_body_util` crate. This
trait provides two methods, `box_body` and `box_body_unsync`, which
allow you to box the body of an `http::Response` to make writing code
that returns responses with different body types easier.

```rust
use bytes::Bytes;
use http::{Response, StatusCode};
use http_body_util::{Empty, Full, ResponseExt};

let response = match uri.path() {
    "/greeting" => greeting().box_body(),
    "/empty" => empty().box_body(),
    _ => not_found().box_body(),
}

fn greeting() -> Response<String> {
    Response::new("Hello, World!".to_string())
}

fn empty() -> Response<Empty<Bytes>> {
    Response::new(Empty::new())
}

fn not_found() -> Response<Full<Bytes>> {
    Response::builder()
        .status(StatusCode::NOT_FOUND)
        .body("Not Found".into())
        .unwrap()
}
```
