### PR TITLE
Add Body::try_clone default method

### DIFF
--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -85,6 +85,16 @@ pub trait Body {
     fn size_hint(&self) -> SizeHint {
         SizeHint::default()
     }
+
+    /// Attempt to clone this body if the concrete type supports it.
+    ///
+    /// The default implementation returns `None` to indicate cloning is not supported.
+    fn try_clone(&self) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 impl<T: Body + Unpin + ?Sized> Body for &mut T {


### PR DESCRIPTION
Adds a new [try_clone](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method to the Body trait with a default implementation returning [None](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This allows concrete body implementations to opt into cloning when possible without breaking existing implementations.

Closes: https://github.com/hyperium/http-body/issues/158

Notes:
- The default implementation is non-breaking.
- No other public APIs were modified.