### PR TITLE
chore: fix broken intradoc links

### DIFF
--- a/http-body-util/src/combinators/fuse.rs
+++ b/http-body-util/src/combinators/fuse.rs
@@ -7,10 +7,10 @@ use http_body::{Body, Frame, SizeHint};
 
 /// A "fused" [`Body`].
 ///
-/// This [`Body`] yields [`Poll::Ready(None)`] forever after the underlying body yields
-/// [`Poll::Ready(None)`], or an error [`Poll::Ready(Some(Err(_)))`], once.
+/// This [`Body`] yields `Poll::Ready(None)` forever after the underlying body yields
+/// `Poll::Ready(None)`, or an error `Poll::Ready(Some(Err(_)))`, once.
 ///
-/// Bodies should ideally continue to return [`Poll::Ready(None)`] indefinitely after the end of
+/// Bodies should ideally continue to return `Poll::Ready(None)` indefinitely after the end of
 /// the stream is reached. [`Fuse<B>`] avoids polling its underlying body `B` further after the
 /// underlying stream as ended, which can be useful for implementation that cannot uphold this
 /// guarantee.

--- a/http-body-util/src/lib.rs
+++ b/http-body-util/src/lib.rs
@@ -154,8 +154,8 @@ pub trait BodyExt: http_body::Body {
 
     /// Creates a "fused" body.
     ///
-    /// This [`Body`][http_body::Body] yields [`Poll::Ready(None)`] forever after the underlying
-    /// body yields [`Poll::Ready(None)`], or an error [`Poll::Ready(Some(Err(_)))`], once.
+    /// This [`Body`][http_body::Body] yields `Poll::Ready(None)` forever after the underlying
+    /// body yields `Poll::Ready(None)`, or an error `Poll::Ready(Some(Err(_)))`, once.
     ///
     /// See [`Fuse<B>`][combinators::Fuse] for more information.
     fn fuse(self) -> combinators::Fuse<Self>

--- a/http-body/src/lib.rs
+++ b/http-body/src/lib.rs
@@ -49,16 +49,16 @@ pub trait Body {
     ///
     /// This function returns:
     ///
-    /// - [`Poll::Pending`] if the next frame is not ready yet.
-    /// - [`Poll::Ready(Some(Ok(frame)))`] when the next frame is available.
-    /// - [`Poll::Ready(Some(Err(error)))`] when an error has been reached.
-    /// - [`Poll::Ready(None)`] means that all of the frames in this stream have been returned, and
+    /// - `Poll::Pending` if the next frame is not ready yet.
+    /// - `Poll::Ready(Some(Ok(frame)))` when the next frame is available.
+    /// - `Poll::Ready(Some(Err(error)))` when an error has been reached.
+    /// - `Poll::Ready(None)` means that all of the frames in this stream have been returned, and
     ///   that the end of the stream has been reached.
     ///
-    /// If [`Poll::Ready(Some(Err(error)))`] is returned, this body should be discarded.
+    /// If `Poll::Ready(Some(Err(error)))` is returned, this body should be discarded.
     ///
     /// Once the end of the stream is reached, implementations should continue to return
-    /// [`Poll::Ready(None)`].
+    /// `Poll::Ready(None)`.
     fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
address warnings like the following, when docs are built using the current stable release:

```
 Documenting http-body-util v0.1.3 (/http-body/http-body/http-body-util)
error: unresolved link to `Poll::Ready(None)`
  --> http-body-util/src/combinators/fuse.rs:10:28
   |
10 | /// This [`Body`] yields [`Poll::Ready(None)`] forever after the underlying body yields
   |                            ^^^^^^^^^^^^^^^^^ the enum `Poll` has no variant or associated item named `Ready(None)`
   |
   = note: requested on the command line with `-D rustdoc::broken-intra-doc-links`

error: unresolved link to `Poll::Ready(Some(Ok(frame)))`
  --> http-body/src/lib.rs:53:13
   |
53 |     /// - [`Poll::Ready(Some(Ok(frame)))`] when the next frame is available.
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the enum `Poll` has no variant or associated item named `Ready(Some(Ok(frame)))`
   |
   = note: requested on the command line with `-D rustdoc::broken-intra-doc-links`
```